### PR TITLE
Fix ordering of Object keys

### DIFF
--- a/src/Aeson.purs
+++ b/src/Aeson.purs
@@ -733,8 +733,8 @@ instance
   EncodeAeson (Record row) where
   encodeAeson' rec = do
     Tuple obj indices <-
-      foldr step (Tuple FO.empty Seq.empty) <<< FO.toUnfoldable <$>
-        (sequence $ gEncodeAeson rec (Proxy :: Proxy list))
+      foldr step (Tuple FO.empty Seq.empty) <$> traverse sequence
+        (FO.toUnfoldable $ gEncodeAeson rec (Proxy :: Proxy list))
     pure $ Aeson
       { patchedJson: AesonPatchedJson (fromObject obj)
       , numberIndex: fold indices

--- a/src/Aeson.purs
+++ b/src/Aeson.purs
@@ -710,8 +710,8 @@ instance EncodeAeson Aeson where
 instance EncodeAeson a => EncodeAeson (Object a) where
   encodeAeson' input = do
     Tuple obj indices <-
-      foldr step (Tuple FO.empty Seq.empty) <<< FO.toUnfoldable <$>
-      sequence (encodeAeson' <$> input)
+      foldr step (Tuple FO.empty Seq.empty) <$>
+      traverse (traverse encodeAeson') (FO.toUnfoldable input)
     pure $ Aeson
       { patchedJson: AesonPatchedJson (fromObject obj)
       , numberIndex: fold indices


### PR DESCRIPTION
While chasing the Aeson bug yesterday I reviewed the code very carefully and confirmed that my earlier guess about the ordering of  `Foreign.Object` entries may indeed be a problem.
In two places, we perform an effectful traverse over the `Object`, and after that convert the object to an array (using another traversal, both of them boil down to a for-in loop). The thing is, there's no guarantee from the JS spec that the ordering of effects matches the ordering of elements in the second traversal. Though in practice it seems to be, it is safer not to rely on that.

Relevant [SO question](https://stackoverflow.com/questions/5525795/does-javascript-guarantee-object-property-order/38218582#38218582)