### PR TITLE
Fix BigNumber import

### DIFF
--- a/src/Aeson.js
+++ b/src/Aeson.js
@@ -1,4 +1,4 @@
-const {BigNumber} = require("bignumber.js")
+const BigNumber = require("bignumber.js")
 
 const JSONbig = require("@mlabs-haskell/json-bigint")({})
 


### PR DESCRIPTION
The current import of `bignumber.js` is wrong and causes `TypeError: BigNumber is not a function` to be thrown when trying to use this library.

The fix is simply to not destructure the import's result, this shouldn't cause any backwards compatibility issues as this is the intended way to use `bignumber.js^9.x.x`